### PR TITLE
Add grpc patch fix for Ubunu 19.10 (eoan)

### DIFF
--- a/tensorflow-core/tensorflow-core-api/WORKSPACE
+++ b/tensorflow-core/tensorflow-core-api/WORKSPACE
@@ -11,7 +11,8 @@ http_archive(
     name = "org_tensorflow",
     patches = [
         ":tensorflow-windows.patch", # https://github.com/tensorflow/tensorflow/issues/25213
-        ":tensorflow-api-def.patch"
+        ":tensorflow-api-def.patch",
+        ":tensorflow-grpc-fix-for-gettid.patch" # https://github.com/clearlinux-pkgs/tensorflow/blob/master/Add-grpc-fix-for-gettid.patch
     ],
     patch_args = ["-p1"],
     urls = [

--- a/tensorflow-core/tensorflow-core-api/external/tensorflow-grpc-fix-for-gettid.patch
+++ b/tensorflow-core/tensorflow-core-api/external/tensorflow-grpc-fix-for-gettid.patch
@@ -1,0 +1,112 @@
+From e50d1fa554154b7e398ef7a0357f646e22cd51cf Mon Sep 17 00:00:00 2001
+From: Jianjun Liu <jianjun.liu@intel.com>
+Date: Thu, 29 Aug 2019 14:56:13 +0800
+Subject: [PATCH] Add grpc fix for gettid
+
+Add gettid fix on gettid conflict because of glibc
+
+Signed-off-by: Jianjun Liu <jianjun.liu@intel.com>
+---
+ tensorflow/workspace.bzl                  |  1 +
+ third_party/Rename-gettid-functions.patch | 78 +++++++++++++++++++++++
+ 2 files changed, 79 insertions(+)
+ create mode 100644 third_party/Rename-gettid-functions.patch
+
+diff --git a/tensorflow/workspace.bzl b/tensorflow/workspace.bzl
+index 55d7eb93..33e86087 100755
+--- a/tensorflow/workspace.bzl
++++ b/tensorflow/workspace.bzl
+@@ -486,6 +486,7 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
+     # WARNING: make sure ncteisen@ and vpai@ are cc-ed on any CL to change the below rule
+     tf_http_archive(
+         name = "grpc",
++	patch_file = clean_dep("//third_party:Rename-gettid-functions.patch"),
+         sha256 = "67a6c26db56f345f7cee846e681db2c23f919eba46dd639b09462d1b6203d28c",
+         strip_prefix = "grpc-4566c2a29ebec0835643b972eb99f4306c4234a3",
+         system_build_file = clean_dep("//third_party/systemlibs:grpc.BUILD"),
+diff --git a/third_party/Rename-gettid-functions.patch b/third_party/Rename-gettid-functions.patch
+new file mode 100644
+index 00000000..90bd9115
+--- /dev/null
++++ b/third_party/Rename-gettid-functions.patch
+@@ -0,0 +1,78 @@
++From d1d017390b799c59d6fdf7b8afa6136d218bdd61 Mon Sep 17 00:00:00 2001
++From: Benjamin Peterson <benjamin@dropbox.com>
++Date: Fri, 3 May 2019 08:11:00 -0700
++Subject: [PATCH] Rename gettid() functions.
++
++glibc 2.30 will declare its own gettid; see https://sourceware.org/git/?p=glibc.git;a=commit;h=1d0fc213824eaa2a8f8c4385daaa698ee8fb7c92. Rename the grpc versions to avoid naming conflicts.
++---
++ src/core/lib/gpr/log_linux.cc          | 4 ++--
++ src/core/lib/gpr/log_posix.cc          | 4 ++--
++ src/core/lib/iomgr/ev_epollex_linux.cc | 4 ++--
++ 3 files changed, 6 insertions(+), 6 deletions(-)
++
++diff --git a/src/core/lib/gpr/log_linux.cc b/src/core/lib/gpr/log_linux.cc
++index 561276f0c20..8b597b4cf2f 100644
++--- a/src/core/lib/gpr/log_linux.cc
+++++ b/src/core/lib/gpr/log_linux.cc
++@@ -40,7 +40,7 @@
++ #include <time.h>
++ #include <unistd.h>
++ 
++-static long gettid(void) { return syscall(__NR_gettid); }
+++static long sys_gettid(void) { return syscall(__NR_gettid); }
++ 
++ void gpr_log(const char* file, int line, gpr_log_severity severity,
++              const char* format, ...) {
++@@ -70,7 +70,7 @@ void gpr_default_log(gpr_log_func_args* args) {
++   gpr_timespec now = gpr_now(GPR_CLOCK_REALTIME);
++   struct tm tm;
++   static __thread long tid = 0;
++-  if (tid == 0) tid = gettid();
+++  if (tid == 0) tid = sys_gettid();
++ 
++   timer = static_cast<time_t>(now.tv_sec);
++   final_slash = strrchr(args->file, '/');
++diff --git a/src/core/lib/gpr/log_posix.cc b/src/core/lib/gpr/log_posix.cc
++index b6edc14ab6b..2f7c6ce3760 100644
++--- a/src/core/lib/gpr/log_posix.cc
+++++ b/src/core/lib/gpr/log_posix.cc
++@@ -31,7 +31,7 @@
++ #include <string.h>
++ #include <time.h>
++ 
++-static intptr_t gettid(void) { return (intptr_t)pthread_self(); }
+++static intptr_t sys_gettid(void) { return (intptr_t)pthread_self(); }
++ 
++ void gpr_log(const char* file, int line, gpr_log_severity severity,
++              const char* format, ...) {
++@@ -86,7 +86,7 @@ void gpr_default_log(gpr_log_func_args* args) {
++   char* prefix;
++   gpr_asprintf(&prefix, "%s%s.%09d %7" PRIdPTR " %s:%d]",
++                gpr_log_severity_string(args->severity), time_buffer,
++-               (int)(now.tv_nsec), gettid(), display_file, args->line);
+++               (int)(now.tv_nsec), sys_gettid(), display_file, args->line);
++ 
++   fprintf(stderr, "%-70s %s\n", prefix, args->message);
++   gpr_free(prefix);
++diff --git a/src/core/lib/iomgr/ev_epollex_linux.cc b/src/core/lib/iomgr/ev_epollex_linux.cc
++index 08116b3ab53..76f59844312 100644
++--- a/src/core/lib/iomgr/ev_epollex_linux.cc
+++++ b/src/core/lib/iomgr/ev_epollex_linux.cc
++@@ -1102,7 +1102,7 @@ static void end_worker(grpc_pollset* pollset, grpc_pollset_worker* worker,
++ }
++ 
++ #ifndef NDEBUG
++-static long gettid(void) { return syscall(__NR_gettid); }
+++static long sys_gettid(void) { return syscall(__NR_gettid); }
++ #endif
++ 
++ /* pollset->mu lock must be held by the caller before calling this.
++@@ -1122,7 +1122,7 @@ static grpc_error* pollset_work(grpc_pollset* pollset,
++ #define WORKER_PTR (&worker)
++ #endif
++ #ifndef NDEBUG
++-  WORKER_PTR->originator = gettid();
+++  WORKER_PTR->originator = sys_gettid();
++ #endif
++   if (GRPC_TRACE_FLAG_ENABLED(grpc_polling_trace)) {
++     gpr_log(GPR_INFO,
+-- 
+2.22.0


### PR DESCRIPTION
(See https://github.com/clearlinux-pkgs/tensorflow/blob/master/Add-grpc-fix-for-gettid.patch)